### PR TITLE
Fixed issue where any staff editing another account's user info from …

### DIFF
--- a/SigmaPi/UserInfo/views.py
+++ b/SigmaPi/UserInfo/views.py
@@ -185,7 +185,7 @@ def edit_user(request, user):
 				message = "Profile successfully updated"
 		except UserInfo.DoesNotExist:
 			if request.user.is_staff:
-				user_to_update = User.objects.get(username=request.META["HTTP_REFERER"].split("/")[-2])
+				user_to_update = requested_user
 			else:
 				user_to_update = request.user
 			form = EditUserInfoForm(request.POST)

--- a/SigmaPi/UserInfo/views.py
+++ b/SigmaPi/UserInfo/views.py
@@ -184,8 +184,12 @@ def edit_user(request, user):
 				form.save()
 				message = "Profile successfully updated"
 		except UserInfo.DoesNotExist:
+			if request.user.is_staff:
+				user_to_update = User.objects.get(username=request.META["HTTP_REFERER"].split("/")[-2])
+			else:
+				user_to_update = request.user
 			form = EditUserInfoForm(request.POST)
-			UserInfo.objects.get_or_create(user=request.user,
+			UserInfo.objects.get_or_create(user=user_to_update,
 			                               pledgeClass=PledgeClass.objects.get(id=request.POST["pledgeClass"]),
 			                               phoneNumber=request.POST["phoneNumber"],
 			                               major=request.POST["major"],

--- a/SigmaPi/UserInfo/views.py
+++ b/SigmaPi/UserInfo/views.py
@@ -184,12 +184,7 @@ def edit_user(request, user):
 				form.save()
 				message = "Profile successfully updated"
 		except UserInfo.DoesNotExist:
-			if request.user.is_staff:
-				user_to_update = requested_user
-			else:
-				user_to_update = request.user
-			form = EditUserInfoForm(request.POST)
-			UserInfo.objects.get_or_create(user=user_to_update,
+			UserInfo.objects.get_or_create(user=requested_user,
 			                               pledgeClass=PledgeClass.objects.get(id=request.POST["pledgeClass"]),
 			                               phoneNumber=request.POST["phoneNumber"],
 			                               major=request.POST["major"],


### PR DESCRIPTION
…the website view would either: (1) create the staff member's user_info instead if the staff member did not have a user_info yet; or (2) produce an IntegrityError if the staff member already had a user_info;  if the target user did not already have a user_info