### PR TITLE
Fixed the pledge class drop down to be in oldest -> newest order

### DIFF
--- a/SigmaPi/UserInfo/models.py
+++ b/SigmaPi/UserInfo/models.py
@@ -26,6 +26,7 @@ class PledgeClass(models.Model):
 	class Meta:
 		verbose_name_plural = "Pledge Classes"
 		verbose_name = "Pledge Class"
+		ordering = ['dateInitiated']
 
 class UserInfo(models.Model):
 	"""


### PR DESCRIPTION
Well.... that is assuming that the "Pledge Class" Userinfo object has its `dateInitiated` field correctly set (the current pledge class `dateInitiated` can just be the date it is created in the db as that date will be after all the previous classes `dateInitiated`s). If not we could always either: (1) Hard code the Greek alphabet into the website and do some magic with form templates; or (2) add the pledge classes in the correct order in the back end since Django will generate the form in the order that they were created (I assume it uses the primary key which just happens to be the id).

I kept this in master because it is literally one line of code that should in all cases be a fast forward merge