### PR TITLE
Make it so users with multiple calendar keys see multiple links

### DIFF
--- a/SigmaPi/Secure/templates/secure_home.html
+++ b/SigmaPi/Secure/templates/secure_home.html
@@ -5,23 +5,29 @@
 
 <h3>{{title}}</h3>
 
-{% if calendar_url %}
+{% if calendar_name_url_pairs %}
+
+{% if calendar_name_url_pairs|length == 1 %}
 <p>
-  Click <a href="{{calendar_url}}" target="_blank">here</a>
+  Click <a href="{{calendar_name_url_pairs.0.1}}" target="_blank">here</a>
   to view the calendar in its own page.
 </p>
+{% else %}
+<p>
+  View the calendar in its own page as:
+  <ul>
+    {% for pair in calendar_name_url_pairs %}
+    <li><a href="{{pair.1}}" target="_blank">{{pair.0}}</a></li>
+    {% endfor %}
+  </ul>
+</p>
+{% endif %}
+
 <div class="table-responsive nospaced">
-  <iframe width="100%" style="height: 60vh;" src="{{calendar_url}}" frameborder="0"></iframe>
+  <iframe width="100%" style="height: 60vh;"
+  src="{{calendar_name_url_pairs.0.1}}" frameborder="0"></iframe>
 </div>
 
-{% elif general_calendar_url %}
-<p>
-  Click <a href="{{general_calendar_url}}" target="_blank">here</a>
-  to view the calendar in its own page.
-</p>
-<div class="table-responsive nospaced">
-  <iframe width="100%" style="height: 60vh;" src="{{general_calendar_url}}" frameborder="0"></iframe>
-</div>
 {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
The title and code are pretty self-explanatory (if they're not, let me know and I'll elaborate more). I tested it pretty thoroughly locally. Give it a look @austintrose @co1in @tmwbook 

Note: The embedded calendar is always displayed as the first calendar the user has access to, with the officer calendars taking priority over the Brothers/Pledges calendar. My thought was that multi-position officers are rare enough that we don't have to worry about making the embedded calendar support them.